### PR TITLE
Check exit code of external tools; python 3 support

### DIFF
--- a/FileSplitter.py
+++ b/FileSplitter.py
@@ -20,8 +20,7 @@ class FileSplitter:
         file_number = 1
         line_number = 1
 
-        print "Splitting %s into multiple files with %s lines" % (os.path.join(self.working_dir, self.file_base_name+self.file_ext), str(self.split_size
-))
+        print("Splitting %s into multiple files with %s lines" % (os.path.join(self.working_dir, self.file_base_name+self.file_ext), str(self.split_size)))
 
         out_file = self.get_new_file(file_number)
         for line in self.in_file:
@@ -35,13 +34,13 @@ class FileSplitter:
 
         out_file.close()
 
-        print "Created %s files." % (str(file_number))
+        print("Created %s files." % (str(file_number)))
 
     def get_new_file(self,file_number):
         """return a new file object ready to write to"""
         new_file_name = "%s.%s%s" % (self.file_base_name, str(file_number), self.file_ext)
         new_file_path = os.path.join(self.working_dir, new_file_name)
-        #print "creating file %s" % (new_file_path)
+        #print("creating file %s" % (new_file_path))
         return open(new_file_path, 'w')
 
     def parse_args(self,argv):
@@ -55,7 +54,7 @@ class FileSplitter:
             self.working_dir = os.getcwd()
             self.file_base_name, self.file_ext = os.path.splitext(self.file_name)
         except:
-            print self.usage()
+            print(self.usage())
             sys.exit(1)
 
     def usage(self):

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ TDNAscan has been tested on the following Linux distributions:
 
 * Ubuntu 14.04 LTS
 * Ubuntu 16.04 LTS
+* Ubuntu 18.04 LTS
+* Ubuntu 20.04 LTS
 * CentOS 7.3
 * Debian 7 "Wheezy"
 * Debian 8 "Jessie"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TDNAscan has been tested on the following Linux distributions:
 The following programs need to be installed and the executable commands should be in $PATH of system.
 * BWA (Version ="0.7.12")
 * Samtools (Version ="1.3.1")
-* Python (Version ="2.7.5")
+* Python (Version at least 3.6.x)
 
 
 # Using TDNAscan

--- a/tdnaAnnot.py
+++ b/tdnaAnnot.py
@@ -36,7 +36,7 @@ def processGFF(file):
             data = line.strip().split("\t")
             if data[2] == "gene":
                 geneID = data[8].strip().split(";")[1].split("=")[1]
-                if geneInfo.has_key(data[0]):
+                if data[0] in geneInfo:
                     geneInfo[data[0]].append((int(data[3]),int(data[4]),geneID))
                 else:
                     geneInfo[data[0]] = [(int(data[3]),int(data[4]),geneID)]
@@ -61,12 +61,12 @@ def annotateVar(varInfo,geneInfo):
     for chr,start,end in varInfo:
         #print(chr,start,end)
         flag = 0
-        if not geneInfo.has_key(chr):
+        if not chr in geneInfo:
             geneAnnot[(chr,start,end)] =[]
             continue
         for s,e,id  in geneInfo[chr]:
             if (start>= s and start <= e) or (end>=s and end <= e):
-                if geneAnnot.has_key((chr,start,end)):
+                if (chr,start,end) in geneAnnot:
                     geneAnnot[(chr,start,end)].append(id)
                 else:
                     flag = 1

--- a/tdnaAnnot.py
+++ b/tdnaAnnot.py
@@ -59,7 +59,7 @@ def processVar(file):
 def annotateVar(varInfo,geneInfo):  
     geneAnnot = {}
     for chr,start,end in varInfo:
-        #print chr,start,end
+        #print(chr,start,end)
         flag = 0
         if not geneInfo.has_key(chr):
             geneAnnot[(chr,start,end)] =[]
@@ -106,7 +106,7 @@ ofile = args.ofile
 
 
 if len(sys.argv) == 1:
-	print parser.print_help()
+	print(parser.print_help())
 	sys.exit("error: give me your input and output files!")
 
 ############################# read AF files #############################
@@ -114,7 +114,7 @@ else :
     geneInfo = processGFF(ffile)
     varInfo = processVar(ifile)
     geneAnnot = annotateVar(varInfo,geneInfo)
-    #print geneAnnot
+    #print(geneAnnot)
 
 ############################# write unique variance to output file #############################
 FileOUT = open(ofile,"w")
@@ -126,4 +126,4 @@ FileOUT.close()
 
 t1 = time.time()
 totalTime = t1-t0
-print "Run time: " + str(totalTime) + "sec"
+print("Run time: " + str(totalTime) + "sec")


### PR DESCRIPTION
Hi,

I noticed that tdnascan.py does not check the exit code for all external command invocations; this PR:

* replaces all os.system() calls by subprocess.call() and subsequent checking of the return code
* adds support for python 3

I successfully applied your software to analyze several datasets with python 3.8, bwa 0.7.17, and
samtools 1.10.